### PR TITLE
Fixing WCSAdminTest

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
@@ -41,7 +41,6 @@ import org.apache.wicket.request.cycle.IRequestCycleListener;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.http.WebRequest;
 import org.apache.wicket.request.http.WebResponse;
-import org.apache.wicket.request.resource.JavaScriptResourceReference;
 import org.apache.wicket.resource.JQueryResourceReference;
 import org.apache.wicket.resource.loader.IStringResourceLoader;
 import org.apache.wicket.settings.RequestCycleSettings.RenderStrategy;

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
@@ -43,7 +43,6 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.request.mapper.parameter.INamedParameters.Type;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.apache.wicket.request.resource.JavaScriptResourceReference;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.resource.JQueryResourceReference;
 import org.geoserver.catalog.Catalog;

--- a/src/web/wcs/src/test/java/org/geoserver/wcs/web/WCSAdminPageTest.java
+++ b/src/web/wcs/src/test/java/org/geoserver/wcs/web/WCSAdminPageTest.java
@@ -5,12 +5,15 @@
  */
 package org.geoserver.wcs.web;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Locale;
+import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.wcs.WCSInfo;
 import org.geoserver.web.wicket.KeywordsEditor;
-import org.junit.Ignore;
+import org.geotools.api.util.InternationalString;
 import org.junit.Test;
 
 public class WCSAdminPageTest extends GeoServerWicketCoverageTestSupport {
@@ -30,18 +33,15 @@ public class WCSAdminPageTest extends GeoServerWicketCoverageTestSupport {
         tester.assertModelValue("form:keywords", wcs.getKeywords());
     }
 
-    // TODO WICKET8 - Fix this test
-    @Ignore
     @Test
     public void testInternationalContent() {
         login();
 
         // start the page
         tester.startPage(new WCSAdminPage());
-
         FormTester form = tester.newFormTester("form");
 
-        // enable i18n for title
+        // enable i18n for title and add two entries
         form.setValue(
                 "serviceTitleAndAbstract:titleAndAbstract:titleLabel:titleLabel_i18nCheckbox",
                 true);
@@ -51,27 +51,11 @@ public class WCSAdminPageTest extends GeoServerWicketCoverageTestSupport {
         tester.executeAjaxEvent(
                 "form:serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:addNew",
                 "click");
-
-        form.select(
-                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:1:itemProperties:0:component:border:border_body:select",
-                10);
-        form.setValue(
-                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:1:itemProperties:1:component:border:border_body:txt",
-                "an international title");
         tester.executeAjaxEvent(
                 "form:serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:addNew",
                 "click");
-        form.select(
-                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:2:itemProperties:0:component:border:border_body:select",
-                20);
-        form.setValue(
-                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:2:itemProperties:1:component:border:border_body:txt",
-                "another international title");
-        tester.executeAjaxEvent(
-                "form:serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:2:itemProperties:2:component:remove",
-                "click");
 
-        // enable i18n for abstract
+        // enable i18n for abstract and add two entries
         form.setValue(
                 "serviceTitleAndAbstract:titleAndAbstract:abstractLabel:abstractLabel_i18nCheckbox",
                 true);
@@ -81,33 +65,61 @@ public class WCSAdminPageTest extends GeoServerWicketCoverageTestSupport {
         tester.executeAjaxEvent(
                 "form:serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:addNew",
                 "click");
+        tester.executeAjaxEvent(
+                "form:serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:addNew",
+                "click");
+
+        // figure out the locales used in the test (might not be stable across JVMs)
+        @SuppressWarnings("unchecked")
+        DropDownChoice<Locale> select =
+                (DropDownChoice)
+                        tester.getComponentFromLastRenderedPage(
+                                "form:serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:1:itemProperties:0:component:border:border_body:select");
+        Locale l10 = select.getChoices().get(10);
+        Locale l20 = select.getChoices().get(20);
+
+        // fill the form (don't do this in between ajax calls)
+        form.select(
+                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:1:itemProperties:0:component:border:border_body:select",
+                10);
+        form.setValue(
+                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:1:itemProperties:1:component:border:border_body:txt",
+                "an international title");
+        form.select(
+                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:2:itemProperties:0:component:border:border_body:select",
+                20);
+        form.setValue(
+                "serviceTitleAndAbstract:titleAndAbstract:internationalTitle:container:tablePanel:listContainer:items:2:itemProperties:1:component:border:border_body:txt",
+                "another international title");
         form.select(
                 "serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:tablePanel:listContainer:items:1:itemProperties:0:component:border:border_body:select",
                 10);
         form.setValue(
                 "serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:tablePanel:listContainer:items:1:itemProperties:1:component:border:border_body:txt",
-                "an international title");
-        tester.executeAjaxEvent(
-                "form:serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:addNew",
-                "click");
+                "an international abstract");
         form.select(
                 "serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:tablePanel:listContainer:items:2:itemProperties:0:component:border:border_body:select",
                 20);
         form.setValue(
                 "serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:tablePanel:listContainer:items:2:itemProperties:1:component:border:border_body:txt",
-                "another international title");
-        tester.executeAjaxEvent(
-                "form:serviceTitleAndAbstract:titleAndAbstract:internationalAbstract:container:tablePanel:listContainer:items:2:itemProperties:2:component:remove",
-                "click");
+                "another international abstract");
 
         // mandatory fields
         form.setValue("maxInputMemory", "1");
         form.setValue("maxOutputMemory", "1");
         form.setValue("maxRequestedDimensionValues", "1");
+        form.setValue("defaultDeflateCompressionLevel", "5");
 
-        form = tester.newFormTester("form");
         form.submit("submit");
         tester.assertNoErrorMessage();
+
+        WCSInfo wcs = getGeoServer().getService(WCSInfo.class);
+        InternationalString internationalTitle = wcs.getInternationalTitle();
+        assertEquals("an international title", internationalTitle.toString(l10));
+        assertEquals("another international title", internationalTitle.toString(l20));
+        InternationalString internationalAbstract = wcs.getInternationalAbstract();
+        assertEquals("an international abstract", internationalAbstract.toString(l10));
+        assertEquals("another international abstract", internationalAbstract.toString(l20));
     }
 
     @Test


### PR DESCRIPTION
Figured out how to make the test pass, and improved the test a bit. Epic debugging action, althought I'm not exactly clear on what happened. The old test seemed to almost pass by accident (e.g., see that creation of a new form tester before the submit, which seems wrong, but makes the test fail if not executed).

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
